### PR TITLE
[신규] 일기방 초대 링크 유효성 검사 API

### DIFF
--- a/src/main/java/share_diary/diray/exception/memberInviteHistory/AlreadyCheckedInviteException.java
+++ b/src/main/java/share_diary/diray/exception/memberInviteHistory/AlreadyCheckedInviteException.java
@@ -1,0 +1,7 @@
+package share_diary.diray.exception.memberInviteHistory;
+
+import share_diary.diray.exception.http.BadRequestException;
+
+public class AlreadyCheckedInviteException extends BadRequestException {
+
+}

--- a/src/main/java/share_diary/diray/exception/memberInviteHistory/InvalidInviteUuidException.java
+++ b/src/main/java/share_diary/diray/exception/memberInviteHistory/InvalidInviteUuidException.java
@@ -1,0 +1,7 @@
+package share_diary.diray.exception.memberInviteHistory;
+
+import share_diary.diray.exception.http.BadRequestException;
+
+public class InvalidInviteUuidException extends BadRequestException {
+
+}

--- a/src/main/java/share_diary/diray/exception/response/ErrorType.java
+++ b/src/main/java/share_diary/diray/exception/response/ErrorType.java
@@ -12,7 +12,9 @@ import share_diary.diray.exception.member.*;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import share_diary.diray.exception.memberInviteHistory.AlreadyCheckedInviteException;
 import share_diary.diray.exception.memberInviteHistory.InvalidInviteHistoryIdException;
+import share_diary.diray.exception.memberInviteHistory.InvalidInviteUuidException;
 
 @Getter
 public enum ErrorType {
@@ -32,7 +34,9 @@ public enum ErrorType {
 
     D001("D001", "존재하지 않는 일기방입니다.", DiaryRoomNotFoundException.class),
 
-    H001("H001", "유효하지 않은 초대 이력입니다.", InvalidInviteHistoryIdException.class)
+    H001("H001", "유효하지 않은 초대 이력입니다.", InvalidInviteHistoryIdException.class),
+    H002("H002", "유효하지 않은 초대 코드입니다.", InvalidInviteUuidException.class),
+    HOO3("H003", "이미 수락/거절한 초대 링크입니다.", AlreadyCheckedInviteException.class)
     ;
 
     private final String code;

--- a/src/main/java/share_diary/diray/member/MemberController.java
+++ b/src/main/java/share_diary/diray/member/MemberController.java
@@ -8,13 +8,13 @@ import share_diary.diray.auth.domain.AuthenticationPrincipal;
 import share_diary.diray.auth.domain.LoginSession;
 import share_diary.diray.auth.domain.NoAuth;
 import share_diary.diray.exception.member.UpdatePasswordNotCoincide;
+import share_diary.diray.member.dto.MemberDTO;
 import share_diary.diray.member.dto.request.*;
 import share_diary.diray.member.dto.response.MemberResponseDTO;
 import share_diary.diray.member.dto.response.MemberValidationEmailResponseDTO;
 import share_diary.diray.member.dto.response.MemberValidationLoginIdResponseDTO;
 
 import javax.validation.Valid;
-import java.util.Objects;
 
 @Slf4j
 @RestController
@@ -137,5 +137,16 @@ public class MemberController {
             @AuthenticationPrincipal LoginSession auth
     ) {
         return ResponseEntity.ok(memberService.validateCreateDiaryRoom(auth.getId()));
+    }
+
+    /**
+     * 멤버 초대 uuid 유효성 체크 API
+     * */
+    @GetMapping("/uuid/{uuid}")
+    @NoAuth
+    public ResponseEntity<MemberDTO> validateMember(
+            @PathVariable String uuid
+    ) {
+        return ResponseEntity.ok(memberService.validateMember(uuid));
     }
 }

--- a/src/main/java/share_diary/diray/member/dto/MemberDTO.java
+++ b/src/main/java/share_diary/diray/member/dto/MemberDTO.java
@@ -1,0 +1,22 @@
+package share_diary.diray.member.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberDTO {
+
+    protected Long id;
+    protected String loginId;
+    protected String email;
+    protected String password;
+    protected String nickName;
+    protected String joinStatus; // 이건 좀 더 고민
+    protected LocalDateTime joinTime;
+    protected LocalDateTime createDate;
+    protected String createBy;
+    protected LocalDateTime lastModifyDate;
+    protected String lastModifiedBy;
+}

--- a/src/main/java/share_diary/diray/member/mapper/MemberMapper.java
+++ b/src/main/java/share_diary/diray/member/mapper/MemberMapper.java
@@ -1,0 +1,14 @@
+package share_diary.diray.member.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import share_diary.diray.common.mapper.GenericMapper;
+import share_diary.diray.common.mapper.ReferenceMapper;
+import share_diary.diray.member.domain.Member;
+import share_diary.diray.member.dto.MemberDTO;
+
+@Mapper(componentModel = "spring", uses = {
+        ReferenceMapper.class}, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface MemberMapper extends GenericMapper<MemberDTO, Member> {
+
+}

--- a/src/main/java/share_diary/diray/memberInviteHistory/domain/InviteAcceptStatus.java
+++ b/src/main/java/share_diary/diray/memberInviteHistory/domain/InviteAcceptStatus.java
@@ -7,5 +7,6 @@ public enum InviteAcceptStatus {
     INVITE,
     ACCEPT,
     DENY,
-    RE_INVITE
+    RE_INVITE,
+    CANCEL  // 일기방 사라진 경우
 }

--- a/src/main/java/share_diary/diray/memberInviteHistory/domain/MemberInviteHistory.java
+++ b/src/main/java/share_diary/diray/memberInviteHistory/domain/MemberInviteHistory.java
@@ -7,6 +7,10 @@ import javax.persistence.*;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import share_diary.diray.diaryRoom.DiaryRoom;
+import share_diary.diray.exception.BaseException;
+import share_diary.diray.exception.memberInviteHistory.AlreadyCheckedInviteException;
+import share_diary.diray.exception.memberInviteHistory.InvalidInviteHistoryIdException;
+import share_diary.diray.exception.memberInviteHistory.InvalidInviteUuidException;
 import share_diary.diray.member.domain.Member;
 
 import java.util.UUID;
@@ -63,5 +67,13 @@ public class MemberInviteHistory {
 
     public boolean canUpdateStatus() {
         return this.status == InviteAcceptStatus.INVITE || this.status == InviteAcceptStatus.RE_INVITE;
+    }
+
+    public void validateUuid() {
+        if (status.equals(InviteAcceptStatus.ACCEPT) || status.equals(InviteAcceptStatus.DENY)) {
+            throw new AlreadyCheckedInviteException();
+        } else if(status.equals(InviteAcceptStatus.RE_INVITE) || status.equals(InviteAcceptStatus.CANCEL)){
+            throw new InvalidInviteUuidException();
+        }
     }
 }

--- a/src/main/java/share_diary/diray/memberInviteHistory/domain/MemberInviteHistoryRepositoryCustom.java
+++ b/src/main/java/share_diary/diray/memberInviteHistory/domain/MemberInviteHistoryRepositoryCustom.java
@@ -8,4 +8,6 @@ public interface MemberInviteHistoryRepositoryCustom {
     List<MemberInviteHistory> findAllByEmailAndRoomIdWithMemberAndDiaryRoom(Long roomId, List<String> emails);
 
     Optional<MemberInviteHistory> findByIdWithMemberAndDiaryRoom(Long historyId);
+
+    Optional<MemberInviteHistory> findByUuidWithMember(String uuid);
 }

--- a/src/main/java/share_diary/diray/memberInviteHistory/domain/impl/MemberInviteHistoryRepositoryCustomImpl.java
+++ b/src/main/java/share_diary/diray/memberInviteHistory/domain/impl/MemberInviteHistoryRepositoryCustomImpl.java
@@ -40,4 +40,14 @@ public class MemberInviteHistoryRepositoryCustomImpl extends QuerydslRepositoryS
                         .fetchOne()
         );
     }
+
+    @Override
+    public Optional<MemberInviteHistory> findByUuidWithMember(String uuid) {
+        return Optional.ofNullable(
+                from(memberInviteHistory)
+                        .join(memberInviteHistory.member).fetchJoin()
+                        .where(memberInviteHistory.uuid.eq(uuid))
+                        .fetchOne()
+        );
+    }
 }


### PR DESCRIPTION
일기방 초대 링크 유효성 검사 API

유효하지 않은 케이스
 1) 이미 수락, 거절한 경우
 2) 일기방이 없어진 경우
 3) 링크 자체가 유효하지 않은 경우

유효한 케이스
1) 원래 회원이었고, 초대받은 경우 -> 로그인 페이지로 리다이렉트
2) 원래 회원이 아니어서 임시로 회원 생성한 경우 -> 회원가입 페이지로 리다이렉트 필요
