### PR TITLE
feat() : 회원 알림 조회 api 개발

### DIFF
--- a/http/MemberInviteHistory.http
+++ b/http/MemberInviteHistory.http
@@ -1,0 +1,4 @@
+### 알림 조회 api
+
+GET http://localhost:8080/api/v0/member-invite-histories
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjk1MjIwMDg3LCJleHAiOjE2OTUyMjE4ODd9.bYS6n4xmJkvflLVZ11Uh-GG9WnrmNnuU1QvpKD_Ap-U

--- a/src/main/java/share_diary/diray/memberInviteHistory/MemberInviteHistoryService.java
+++ b/src/main/java/share_diary/diray/memberInviteHistory/MemberInviteHistoryService.java
@@ -18,7 +18,9 @@ import share_diary.diray.member.domain.MemberRepository;
 import share_diary.diray.memberInviteHistory.domain.InviteAcceptStatus;
 import share_diary.diray.memberInviteHistory.domain.MemberInviteHistory;
 import share_diary.diray.memberInviteHistory.domain.MemberInviteHistoryRepository;
+import share_diary.diray.memberInviteHistory.dto.MemberInviteHistoryDTO;
 import share_diary.diray.memberInviteHistory.event.InviteAcceptEvent;
+import share_diary.diray.memberInviteHistory.mapper.MemberInviteHistoryMapper;
 
 @Slf4j
 @Service
@@ -30,6 +32,7 @@ public class MemberInviteHistoryService {
     private final MemberInviteHistoryRepository memberInviteHistoryRepository;
     private final EmailSenderComponent emailSenderComponent;
     private final ApplicationEventPublisher publisher;
+    private final MemberInviteHistoryMapper inviteHistoryMapper;
 
     public void inviteRoomMembers(MemberInviteRequest request) {
         // 일기방 검증
@@ -95,12 +98,14 @@ public class MemberInviteHistoryService {
         }
     }
 
-    public void findByLoginUserInviteHistory(Long loginId){
+    public List<MemberInviteHistoryDTO> findByLoginUserInviteHistory(Long loginId){
         List<MemberInviteHistory> inviteHistories = memberInviteHistoryRepository.findAllByMemberInviteHistories(loginId);
 
         if(inviteHistories.isEmpty()){
             //추후 custom exception 추가
             throw new IllegalArgumentException();
         }
+        List<MemberInviteHistoryDTO> dtoList = inviteHistoryMapper.asDTOList(inviteHistories);
+        return dtoList;
     }
 }

--- a/src/main/java/share_diary/diray/memberInviteHistory/controller/MemberInviteHistoryController.java
+++ b/src/main/java/share_diary/diray/memberInviteHistory/controller/MemberInviteHistoryController.java
@@ -13,6 +13,9 @@ import share_diary.diray.memberInviteHistory.MemberInviteHistoryService;
 import share_diary.diray.memberInviteHistory.MemberInviteRequest;
 import share_diary.diray.memberInviteHistory.controller.request.InviteUpdateRequest;
 import share_diary.diray.memberInviteHistory.domain.InviteAcceptStatus;
+import share_diary.diray.memberInviteHistory.dto.MemberInviteHistoryDTO;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -57,9 +60,9 @@ public class MemberInviteHistoryController {
     @GetMapping
     @NoAuth
     //TODO[jipdol2] : MemberInviteHistory Entity 에 '누가' 초대를 했는지 알 수 있도록 필드 추가 필요...
-    public ResponseEntity<HttpStatus> findByInviteHistory(@AuthenticationPrincipal LoginSession loginSession){
-        memberInviteHistoryService.findByLoginUserInviteHistory(loginSession.getId());
-        return ResponseEntity.ok(HttpStatus.OK);
+    public ResponseEntity<List<MemberInviteHistoryDTO>> findByInviteHistory(@AuthenticationPrincipal LoginSession loginSession){
+        List<MemberInviteHistoryDTO> byLoginUserInviteHistory = memberInviteHistoryService.findByLoginUserInviteHistory(loginSession.getId());
+        return ResponseEntity.ok(byLoginUserInviteHistory);
     }
 
 }

--- a/src/main/java/share_diary/diray/memberInviteHistory/domain/MemberInviteHistory.java
+++ b/src/main/java/share_diary/diray/memberInviteHistory/domain/MemberInviteHistory.java
@@ -36,6 +36,9 @@ public class MemberInviteHistory {
     @Enumerated(value = STRING)
     private InviteAcceptStatus status;
 
+    @Column
+    private String hostUserId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", referencedColumnName = "id")
     private Member member;

--- a/src/main/java/share_diary/diray/memberInviteHistory/dto/MemberInviteHistoryDTO.java
+++ b/src/main/java/share_diary/diray/memberInviteHistory/dto/MemberInviteHistoryDTO.java
@@ -1,0 +1,19 @@
+package share_diary.diray.memberInviteHistory.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import share_diary.diray.memberInviteHistory.domain.InviteAcceptStatus;
+
+@Getter
+@AllArgsConstructor
+public class MemberInviteHistoryDTO {
+
+    private Long id;
+    private String uuid;
+    private String email;
+    private String hostUserId;
+    private InviteAcceptStatus status;
+    private Long memberId;
+    private Long diaryRoomId;
+
+}

--- a/src/main/java/share_diary/diray/memberInviteHistory/mapper/MemberInviteHistoryMapper.java
+++ b/src/main/java/share_diary/diray/memberInviteHistory/mapper/MemberInviteHistoryMapper.java
@@ -1,0 +1,13 @@
+package share_diary.diray.memberInviteHistory.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import share_diary.diray.common.mapper.GenericMapper;
+import share_diary.diray.common.mapper.ReferenceMapper;
+import share_diary.diray.memberInviteHistory.domain.MemberInviteHistory;
+import share_diary.diray.memberInviteHistory.dto.MemberInviteHistoryDTO;
+
+@Mapper(componentModel = "spring", uses = {
+        ReferenceMapper.class}, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface MemberInviteHistoryMapper extends GenericMapper<MemberInviteHistoryDTO,MemberInviteHistory> {
+}


### PR DESCRIPTION
1. entity -> dto 로 변경하는 mapper 를 추가하였습니다.
2. MemberInviteHistory entity 에 메일을 보낸 hostUserId 컬럼을 추가하였습니다
- 메일을 전송할때 보낸 유저의 아이디를 추가하려면 @AuthenticationPrincipal 어노테이션을 사용한 LoginSession 객체를 파라미터로 받아야 하는데, 현재 구조상 (event) package 에 DiaryRoomCreateEventListenerImpl class > handleDiaryRoomCreateEvent method 때문에 수정이 불가피 합니다.
3. 클라이언트로 return 해줄 dto class 와 package 를 생성하였습니다.